### PR TITLE
open_files is thread safe, set default values for owner, group, mode

### DIFF
--- a/local_gridfile.cpp
+++ b/local_gridfile.cpp
@@ -8,7 +8,7 @@ int LocalGridFile::write(const char *buf, size_t nbyte, off_t offset) {
   size_t last_chunk = (offset + nbyte) / _chunkSize;
   size_t written = 0;
 
-  while(last_chunk > _chunks.size() - 1) {
+  while (last_chunk > _chunks.size() - 1) {
     char *new_buf = new char[_chunkSize];
     memset(new_buf, 0, _chunkSize);
     _chunks.push_back(new_buf);
@@ -17,7 +17,7 @@ int LocalGridFile::write(const char *buf, size_t nbyte, off_t offset) {
   off_t chunk_num = offset / _chunkSize;
   off_t buf_offset = offset % _chunkSize;
 
-  char* dest_buf = _chunks[chunk_num];
+  char *dest_buf = _chunks[chunk_num];
   if (buf_offset) {
     dest_buf += offset % _chunkSize;
     size_t to_write = min<size_t>(nbyte - written, _chunkSize - buf_offset);
@@ -26,7 +26,7 @@ int LocalGridFile::write(const char *buf, size_t nbyte, off_t offset) {
     chunk_num++;
   }
 
-  while(written < nbyte) {
+  while (written < nbyte) {
     dest_buf = _chunks[chunk_num];
     size_t to_write = min<size_t>(nbyte - written, _chunkSize);
     memcpy(dest_buf, buf, to_write);
@@ -40,12 +40,12 @@ int LocalGridFile::write(const char *buf, size_t nbyte, off_t offset) {
   return written;
 }
 
-int LocalGridFile::read(char* buf, size_t size, off_t offset) {
+int LocalGridFile::read(char *buf, size_t size, off_t offset) {
   size_t len = 0;
   size_t chunk_num = offset / _chunkSize;
 
   while (len < size && chunk_num < _chunks.size()) {
-    const char* chunk = _chunks[chunk_num];
+    const char *chunk = _chunks[chunk_num];
     size_t to_read = min<size_t>((size_t)_chunkSize, size - len);
 
     if (!len && offset) {

--- a/local_gridfile.h
+++ b/local_gridfile.h
@@ -25,36 +25,65 @@ public:
     _chunks.push_back(new char[_chunkSize]);
   }
 
+  LocalGridFile(const LocalGridFile &other) = delete;
+  LocalGridFile &operator=(const LocalGridFile &other) = delete;
+
   ~LocalGridFile() {
     for (auto i : _chunks) {
       delete i;
     }
   }
 
-  int Length() const { return _length; }
+  int Length() const {
+    return _length;
+  }
 
-  int ChunkSize() const { return _chunkSize; }
+  int ChunkSize() const {
+    return _chunkSize;
+  }
 
-  int NumChunks() const { return _chunks.size(); }
+  int NumChunks() const {
+    return _chunks.size();
+  }
 
-  char* Chunk(int n) const { return _chunks[n]; }
+  char *Chunk(int n) const {
+    return _chunks[n];
+  }
 
-  uid_t Uid() const { return _uid; }
-  void setUid(uid_t u) { _uid = u; }
+  uid_t Uid() const {
+    return _uid;
+  }
+  void setUid(uid_t u) {
+    _uid = u;
+  }
 
-  gid_t Gid() const { return _gid; }
-  void setGid(gid_t g) { _gid = g; }
+  gid_t Gid() const {
+    return _gid;
+  }
+  void setGid(gid_t g) {
+    _gid = g;
+  }
 
-  mode_t Mode() const { return _mode; }
-  void setMode(mode_t m) { _mode = m; }
+  mode_t Mode() const {
+    return _mode;
+  }
+  void setMode(mode_t m) {
+    _mode = m;
+  }
 
-  bool is_dirty() const { return _dirty; }
-  bool is_clean() const { return !_dirty; }
+  bool is_dirty() const {
+    return _dirty;
+  }
+  bool is_clean() const {
+    return !_dirty;
+  }
 
-  void set_flushed() { _dirty = false; }
+  void set_flushed() {
+    _dirty = false;
+  }
 
-  int write(const char* buf, size_t nbyte, off_t offset);
-  int read(char* buf, size_t size, off_t offset);
+  int write(const char *buf, size_t nbyte, off_t offset);
+  int read(char *buf, size_t size, off_t offset);
 
   typedef std::shared_ptr<LocalGridFile> ptr;
 
@@ -65,7 +94,7 @@ private:
   mode_t _mode;
 
   bool _dirty;
-  std::vector<char*> _chunks;
+  std::vector<char *> _chunks;
 };
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -27,8 +27,7 @@
 
 using namespace std;
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
   static struct fuse_operations gridfs_oper;
   gridfs_oper.getattr = gridfs_getattr;
   gridfs_oper.readlink = gridfs_readlink;
@@ -55,8 +54,9 @@ int main(int argc, char *argv[])
   struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
 
   memset(&gridfs_options, 0, sizeof(struct gridfs_options));
-  if (fuse_opt_parse(&args, &gridfs_options, gridfs_opts, gridfs_opt_proc) == -1)
+  if (fuse_opt_parse(&args, &gridfs_options, gridfs_opts, gridfs_opt_proc) == -1) {
     return -1;
+  }
 
   if (!gridfs_options.host) {
     gridfs_options.host = "localhost";
@@ -64,11 +64,11 @@ int main(int argc, char *argv[])
 
   mongo::ConnectionString cs;
   if (!gridfs_options.port) {
-    gridfs_options.port = 0;
-  } else {
-    cs = mongo::ConnectionString(mongo::HostAndPort(gridfs_options.host, gridfs_options.port));
-    gridfs_options.conn_string = &cs;
+    gridfs_options.port = 27017;
   }
+
+  cs = mongo::ConnectionString(mongo::HostAndPort(gridfs_options.host, gridfs_options.port));
+  gridfs_options.conn_string = &cs;
 
   if (!gridfs_options.db) {
     gridfs_options.db = "test";

--- a/operations.h
+++ b/operations.h
@@ -26,6 +26,7 @@
 #define ENOATTR 93
 #endif
 
+#include <mutex>
 #include <map>
 #include <fuse.h>
 #include <mongo/client/connpool.h>
@@ -33,49 +34,60 @@
 #include "local_gridfile.h"
 #include "options.h"
 
-extern std::map<std::string, LocalGridFile::ptr> open_files;
+LocalGridFile::ptr
+get_open(const char *path);
 
-int gridfs_getattr(const char* path, struct stat *stbuf);
+LocalGridFile::ptr
+set_open(const char *path, uid_t u, gid_t g, mode_t m, int chunkSize = DEFAULT_CHUNK_SIZE);
 
-int gridfs_readlink(const char* path, char* buf, size_t size);
+void
+remove_open(const char *path);
 
-int gridfs_mkdir(const char* path, mode_t mode);
+std::vector<std::string>
+all_open();
 
-int gridfs_unlink(const char* path);
 
-int gridfs_rmdir(const char* path);
+int gridfs_getattr(const char *path, struct stat *stbuf);
 
-int gridfs_symlink(const char* target, const char* path);
+int gridfs_readlink(const char *path, char *buf, size_t size);
 
-int gridfs_rename(const char* old_path, const char* new_path);
+int gridfs_mkdir(const char *path, mode_t mode);
 
-int gridfs_chmod(const char* path, mode_t mode);
+int gridfs_unlink(const char *path);
 
-int gridfs_chown(const char* path, uid_t uid, gid_t gid);
+int gridfs_rmdir(const char *path);
 
-int gridfs_open(const char* path, struct fuse_file_info *fi);
+int gridfs_symlink(const char *target, const char *path);
 
-int gridfs_read(const char* path, char* buf, size_t size, off_t offset, struct fuse_file_info *fi);
+int gridfs_rename(const char *old_path, const char *new_path);
 
-int gridfs_write(const char* path, const char* buf, size_t nbyte, off_t offset, struct fuse_file_info* ffi);
+int gridfs_chmod(const char *path, mode_t mode);
 
-int gridfs_flush(const char* path, struct fuse_file_info* ffi);
+int gridfs_chown(const char *path, uid_t uid, gid_t gid);
 
-int gridfs_release(const char* path, struct fuse_file_info* ffi);
+int gridfs_open(const char *path, struct fuse_file_info *fi);
 
-int gridfs_setxattr(const char* path, const char* name, const char* value, size_t size, int flags);
+int gridfs_read(const char *path, char *buf, size_t size, off_t offset, struct fuse_file_info *fi);
 
-int gridfs_getxattr(const char* path, const char* name, char* value, size_t size);
+int gridfs_write(const char *path, const char *buf, size_t nbyte, off_t offset, struct fuse_file_info *ffi);
 
-int gridfs_listxattr(const char* path, char* list, size_t size);
+int gridfs_flush(const char *path, struct fuse_file_info *ffi);
 
-int gridfs_removexattr(const char* path, const char* name);
+int gridfs_release(const char *path, struct fuse_file_info *ffi);
 
-int gridfs_readdir(const char* path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi);
+int gridfs_setxattr(const char *path, const char *name, const char *value, size_t size, int flags);
 
-int gridfs_create(const char* path, mode_t mode, struct fuse_file_info* ffi);
+int gridfs_getxattr(const char *path, const char *name, char *value, size_t size);
 
-int gridfs_utimens(const char* path, const struct timespec tv[2]);
+int gridfs_listxattr(const char *path, char *list, size_t size);
+
+int gridfs_removexattr(const char *path, const char *name);
+
+int gridfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi);
+
+int gridfs_create(const char *path, mode_t mode, struct fuse_file_info *ffi);
+
+int gridfs_utimens(const char *path, const struct timespec tv[2]);
 
 std::shared_ptr<mongo::ScopedDbConnection> make_ScopedDbConnection(void);
 

--- a/ops_metadata.cpp
+++ b/ops_metadata.cpp
@@ -25,21 +25,23 @@
 unsigned int subdir_count(mongo::DBClientBase &client, std::string path) {
   mongo::BSONObj proj = BSON("mode" << 1);
   std::string path_start = path;
-  if (path.length() > 0)
+  if (path.length() > 0) {
     path_start += "/";
+  }
 
   std::unique_ptr<mongo::DBClientCursor> cursor = client.query(db_name() + ".files",
-							       BSON("filename" <<
-								    BSON("$regex" << ("^" + path_start + "/[^/]*$"))
-								    ),
-							       0, 0,
-							       &proj);
+      BSON("filename" <<
+           BSON("$regex" << ("^" + path_start + "/[^/]*$"))
+          ),
+      0, 0,
+      &proj);
   std::string lastFN;
   unsigned int count = 0;
   while (cursor->more()) {
     mongo::BSONObj file_obj = cursor->next();
-    if (S_ISDIR(file_obj["mode"].Int()))
+    if (S_ISDIR(file_obj["mode"].Int())) {
       count++;
+    }
   }
 
   return count;
@@ -61,10 +63,9 @@ int gridfs_getattr(const char *path, struct stat *stbuf) {
   }
 
   path = fuse_to_mongo_path(path);
-  auto file_iter = open_files.find(path);
 
-  if (file_iter != open_files.end()) {
-    LocalGridFile::ptr lgf = file_iter->second;
+  auto lgf = get_open(path);
+  if (lgf) {
     stbuf->st_mode = S_IFREG | (lgf->Mode() & (0xffff ^ S_IFMT));
     stbuf->st_nlink = 1;
     stbuf->st_uid = lgf->Uid();
@@ -76,32 +77,34 @@ int gridfs_getattr(const char *path, struct stat *stbuf) {
   }
 
   mongo::BSONObj file_obj = client.findOne(db_name() + ".files",
-					   BSON("filename" << path));
+                            BSON("filename" << path));
 
-  if (file_obj.isEmpty())
+  if (file_obj.isEmpty()) {
     return -ENOENT;
-
-  if (file_obj.hasField("owner")) {
-    passwd *pw = getpwnam(file_obj["owner"].str().c_str());
-    if (pw)
-      stbuf->st_uid = pw->pw_uid;
-  }
-  if (file_obj.hasField("group")) {
-    group *gr = getgrnam(file_obj["group"].str().c_str());
-    if (gr)
-      stbuf->st_gid = gr->gr_gid;
   }
 
-  stbuf->st_mode = file_obj["mode"].Int();
+  passwd *pw = getpwnam(file_obj.hasField("owner") ? file_obj["owner"].str().c_str() : "root");
+  if (pw) {
+    stbuf->st_uid = pw->pw_uid;
+  }
+
+  group *gr = getgrnam(file_obj.hasField("group") ? file_obj["group"].str().c_str() : "root");
+  if (gr) {
+    stbuf->st_gid = gr->gr_gid;
+  }
+
+  stbuf->st_mode = file_obj.hasField("mode") ? file_obj["mode"].Int() : S_IFREG | S_IRUSR | S_IRGRP | S_IROTH;
   if (S_ISREG(stbuf->st_mode)) {
     stbuf->st_nlink = 1;
     stbuf->st_size = file_obj["length"].Int();
     stbuf->st_blocks = stbuf->st_size >> 9;
   }
-  if (S_ISDIR(stbuf->st_mode))
+  if (S_ISDIR(stbuf->st_mode)) {
     stbuf->st_nlink = 2 + subdir_count(client, path);
-  if (S_ISLNK(stbuf->st_mode))
+  }
+  if (S_ISLNK(stbuf->st_mode)) {
     stbuf->st_size = file_obj["target"].String().length();
+  }
 
   time_t upload_time = mongo_time_to_unix_time(file_obj["uploadDate"].date());
   stbuf->st_ctime = upload_time;
@@ -110,29 +113,26 @@ int gridfs_getattr(const char *path, struct stat *stbuf) {
   return 0;
 }
 
-int gridfs_chmod(const char* path, mode_t mode) {
+int gridfs_chmod(const char *path, mode_t mode) {
   path = fuse_to_mongo_path(path);
-  auto file_iter = open_files.find(path);
-
-  if (file_iter != open_files.end()) {
-    LocalGridFile::ptr lgf = file_iter->second;
+  auto lgf = get_open(path);
+  if (lgf) {
     lgf->setMode(mode);
   }
 
   auto sdc = make_ScopedDbConnection();
   sdc->conn().update(db_name() + ".files",
-		     BSON("filename" << path),
-		     BSON("$set" << BSON("mode" << mode)));
+                     BSON("filename" << path),
+                     BSON("$set" << BSON("mode" << mode)));
 
   return 0;
 }
 
-int gridfs_chown(const char* path, uid_t uid, gid_t gid) {
+int gridfs_chown(const char *path, uid_t uid, gid_t gid) {
   path = fuse_to_mongo_path(path);
-  auto file_iter = open_files.find(path);
 
-  if (file_iter != open_files.end()) {
-    LocalGridFile::ptr lgf = file_iter->second;
+  auto lgf = get_open(path);
+  if (lgf) {
     lgf->setUid(uid);
     lgf->setGid(gid);
   }
@@ -141,41 +141,43 @@ int gridfs_chown(const char* path, uid_t uid, gid_t gid) {
 
   {
     passwd *pw = getpwuid(uid);
-    if (pw)
+    if (pw) {
       b.append("owner", pw->pw_name);
+    }
   }
   {
     group *gr = getgrgid(gid);
-    if (gr)
+    if (gr) {
       b.append("group", gr->gr_name);
+    }
   }
 
   if (b.hasField("owner") || b.hasField("group")) {
     auto sdc = make_ScopedDbConnection();
     sdc->conn().update(db_name() + ".files",
-		       BSON("filename" << path),
-		       BSON("$set" << b.obj()));
+                       BSON("filename" << path),
+                       BSON("$set" << b.obj()));
   }
 
   return 0;
 }
 
-int gridfs_utimens(const char* path, const struct timespec tv[2]) {
+int gridfs_utimens(const char *path, const struct timespec tv[2]) {
   path = fuse_to_mongo_path(path);
 
   unsigned long long millis = ((unsigned long long)tv[1].tv_sec * 1000) + (tv[1].tv_nsec / 1e+6);
 
   auto sdc = make_ScopedDbConnection();
   sdc->conn().update(db_name() + ".files",
-		     BSON("filename" << path),
-		     BSON("$set" <<
-			  BSON("uploadDate" << mongo::Date_t(millis))
-			  ));
+                     BSON("filename" << path),
+                     BSON("$set" <<
+                          BSON("uploadDate" << mongo::Date_t(millis))
+                         ));
 
   return 0;
 }
 
-int gridfs_rename(const char* old_path, const char* new_path) {
+int gridfs_rename(const char *old_path, const char *new_path) {
   old_path = fuse_to_mongo_path(old_path);
   new_path = fuse_to_mongo_path(new_path);
 
@@ -183,14 +185,15 @@ int gridfs_rename(const char* old_path, const char* new_path) {
   mongo::DBClientBase &client = sdc->conn();
 
   mongo::BSONObj file_obj = client.findOne(db_name() + ".files",
-				    BSON("filename" << old_path));
+                            BSON("filename" << old_path));
 
-  if (file_obj.isEmpty())
+  if (file_obj.isEmpty()) {
     return -ENOENT;
+  }
 
   client.update(db_name() + ".files",
-		BSON("_id" << file_obj.getField("_id")),
-		BSON("$set" << BSON("filename" << new_path)));
+                BSON("_id" << file_obj.getField("_id")),
+                BSON("$set" << BSON("filename" << new_path)));
 
   return 0;
 }

--- a/ops_xattr.cpp
+++ b/ops_xattr.cpp
@@ -23,17 +23,20 @@
 #include <sys/xattr.h>
 #endif
 
-int gridfs_listxattr(const char* path, char* list, size_t size) {
+int gridfs_listxattr(const char *path, char *list, size_t size) {
   path = fuse_to_mongo_path(path);
-  if (open_files.find(path) != open_files.end())
+
+  if (get_open(path)) {
     return 0;
+  }
 
   auto sdc = make_ScopedDbConnection();
   mongo::GridFS gf = get_gridfs(sdc);
   mongo::GridFile file = gf.findFile(path);
 
-  if (!file.exists())
+  if (!file.exists()) {
     return -ENOENT;
+  }
 
   size_t len = 0;
   mongo::BSONObj metadata = file.getMetadata();
@@ -49,109 +52,130 @@ int gridfs_listxattr(const char* path, char* list, size_t size) {
     }
   }
 
-  if (size == 0)
+  if (size == 0) {
     return len;
-  if (len >= size)
+  }
+  if (len >= size) {
     return -ERANGE;
+  }
 
   return len;
 }
 
-int gridfs_getxattr(const char* path, const char* name, char* value, size_t size) {
-  if (strcmp(path, "/") == 0)
+int gridfs_getxattr(const char *path, const char *name, char *value, size_t size) {
+  if (strcmp(path, "/") == 0) {
     return -ENODATA;
+  }
 
-  const char* attr_name = unnamespace_xattr(name);
-  if (!attr_name)
+  const char *attr_name = unnamespace_xattr(name);
+  if (!attr_name) {
     return -ENODATA;
+  }
 
   path = fuse_to_mongo_path(path);
-  if (open_files.find(path) != open_files.end())
+
+  if (get_open(path)) {
     return -ENOATTR;
+  }
 
   auto sdc = make_ScopedDbConnection();
   mongo::GridFS gf = get_gridfs(sdc);
   mongo::GridFile file = gf.findFile(path);
 
-  if (!file.exists())
+  if (!file.exists()) {
     return -ENOENT;
+  }
 
   mongo::BSONObj metadata = file.getMetadata();
-  if (metadata.isEmpty())
+  if (metadata.isEmpty()) {
     return -ENOATTR;
+  }
 
   mongo::BSONElement field = metadata[attr_name];
-  if (field.eoo())
+  if (field.eoo()) {
     return -ENOATTR;
+  }
 
   std::string field_str = field.toString();
   size_t len = field_str.size() + 1;
-  if (size == 0)
+  if (size == 0) {
     return len;
-  if (len >= size)
+  }
+  if (len >= size) {
     return -ERANGE;
+  }
 
   memcpy(value, field_str.c_str(), len);
 
   return len;
 }
 
-int gridfs_setxattr(const char* path, const char* name, const char* value, size_t size, int flags) {
-  if (strcmp(path, "/") == 0)
+int gridfs_setxattr(const char *path, const char *name, const char *value, size_t size, int flags) {
+  if (strcmp(path, "/") == 0) {
     return -ENODATA;
+  }
 
-  const char* attr_name = unnamespace_xattr(name);
-  if (!attr_name)
+  const char *attr_name = unnamespace_xattr(name);
+  if (!attr_name) {
     return -ENODATA;
+  }
 
   path = fuse_to_mongo_path(path);
-  if (open_files.find(path) != open_files.end())
+
+  if (get_open(path)) {
     return -ENOATTR;
+  }
 
   auto sdc = make_ScopedDbConnection();
   mongo::DBClientBase &client = sdc->conn();
 
   mongo::BSONObj file_obj = client.findOne(db_name() + ".files",
-					   BSON("filename" << path));
+                            BSON("filename" << path));
 
-  if (file_obj.isEmpty())
+  if (file_obj.isEmpty()) {
     return -ENOENT;
+  }
 
   client.update(db_name() + ".files",
-		BSON("filename" << path),
-		BSON("$set" <<
-		     BSON((std::string("metadata.") + attr_name) << value)
-		     ));
+                BSON("filename" << path),
+                BSON("$set" <<
+                     BSON((std::string("metadata.") + attr_name) << value)
+                    ));
 
   return 0;
 }
 
-int gridfs_removexattr(const char* path, const char* name) {
-  if (strcmp(path, "/") == 0)
+int gridfs_removexattr(const char *path, const char *name) {
+  if (strcmp(path, "/") == 0) {
     return -ENODATA;
+  }
 
-  const char* attr_name = unnamespace_xattr(name);
-  if (!attr_name)
+  const char *attr_name = unnamespace_xattr(name);
+  if (!attr_name) {
     return -ENODATA;
+  }
 
   path = fuse_to_mongo_path(path);
-  if (open_files.find(path) != open_files.end())
+
+  if (get_open(path)) {
     return -ENOATTR;
+  }
 
   auto sdc = make_ScopedDbConnection();
   mongo::DBClientBase &client = sdc->conn();
 
   mongo::BSONObj file_obj = client.findOne(db_name() + ".files",
-					   BSON("filename" << path));
+                            BSON("filename" << path));
 
-  if (file_obj.isEmpty())
+  if (file_obj.isEmpty()) {
     return -ENOENT;
+  }
 
   client.update(db_name() + ".files",
-		BSON("filename" << path),
-		BSON("$unset" <<
-		     BSON((std::string("metadata.") + attr_name) << "")
-		     ));
+                BSON("filename" << path),
+                BSON("$unset" <<
+                     BSON((std::string("metadata.") + attr_name) << "")
+                    ));
 
   return 0;
 }

--- a/options.cpp
+++ b/options.cpp
@@ -36,7 +36,7 @@ struct fuse_opt gridfs_opts[] = {
   NULL
 };
 
-int gridfs_opt_proc(void* data, const char* arg, int key, struct fuse_args* outargs) {
+int gridfs_opt_proc(void *data, const char *arg, int key, struct fuse_args *outargs) {
   if (key == KEY_HELP) {
     print_help();
     return -1;

--- a/options.h
+++ b/options.h
@@ -24,13 +24,13 @@
 #include <cstddef>
 
 struct gridfs_options {
-  const char* host;
+  const char *host;
   int port;
   mongo::ConnectionString *conn_string;
-  const char* db;
-  const char* prefix;
-  const char* username;
-  const char* password;
+  const char *db;
+  const char *prefix;
+  const char *username;
+  const char *password;
 };
 
 extern gridfs_options gridfs_options;
@@ -44,11 +44,13 @@ enum {
 
 extern struct fuse_opt gridfs_opts[];
 
-int gridfs_opt_proc(void* data, const char* arg, int key,
-          struct fuse_args* outargs);
+int gridfs_opt_proc(void *data, const char *arg, int key,
+                    struct fuse_args *outargs);
 
 void print_help();
 
-inline std::string db_name() { return std::string(gridfs_options.db) + "." + gridfs_options.prefix; }
+inline std::string db_name() {
+  return std::string(gridfs_options.db) + "." + gridfs_options.prefix;
+}
 
 #endif

--- a/utils.h
+++ b/utils.h
@@ -22,26 +22,33 @@
 #include <string>
 #include <cstring>
 
-inline const char* fuse_to_mongo_path(const char* path) {
-  if (path[0] == '/')
+inline const char *fuse_to_mongo_path(const char *path) {
+  if (path[0] == '/') {
     return path + 1;
+  }
   return path;
 }
 
-inline const bool is_leaf(const char* path) {
+inline const bool is_leaf(const char *path) {
   int pp = -1;
   int sp = -1;
   for (size_t i = 0; i < strlen(path); i++) {
-    if (path[i] == '/') sp = i;
-    if (path[i] == '.') pp = i;
+    if (path[i] == '/') {
+      sp = i;
+    }
+    if (path[i] == '.') {
+      pp = i;
+    }
   }
   return pp > sp;
 }
 
-inline const int path_depth(const char* path) {
+inline const int path_depth(const char *path) {
   int sc = 0;
-  for (size_t i=0; i < strlen(path); i++) {
-    if (path[i] == '/') sc++;
+  for (size_t i = 0; i < strlen(path); i++) {
+    if (path[i] == '/') {
+      sc++;
+    }
   }
   return sc;
 }
@@ -66,9 +73,9 @@ inline std::string namespace_xattr(const std::string name) {
 #endif
 }
 
-inline const char* unnamespace_xattr(const char* name) {
+inline const char *unnamespace_xattr(const char *name) {
 #ifdef __linux__
-  if(std::strstr(name, "user.") == name) {
+  if (std::strstr(name, "user.") == name) {
     return name + 5;
   } else {
     return NULL;


### PR DESCRIPTION
The variable open_files is now thread safe, before segfault might occur, for example, when trying to copy a file using Midnight Commander.
Fields owner, group, mode, set the default values it allows the use of standard tools for uploading files to the database (mongofiles).
Mongo port has a default value of 27017 previously segfault if it does not specify.
Apply Artistic Style Formatter.
